### PR TITLE
Fix symbol visibility problem on linking

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -27,7 +27,7 @@ CPPSRCS=main.cpp \
 CPPOBJS=$(CPPSRCS:%.cpp=%.o)
 
 all: ${DIRS} ${CPPOBJS}
-	${CXX} ${CXXFLAGS} ${LDFLAGS} ${CPPOBJS} -o ${EXE}
+	${CXX} ${CXXFLAGS} ${CPPOBJS} ${LDFLAGS} -o ${EXE}
 
 %.o: %.cpp %.hpp
 	${CXX} ${CXXFLAGS} -c $<


### PR DESCRIPTION
Object files can see symbols only in libs/objs, listed after them on linking command.
